### PR TITLE
Bieli fix logout frontend

### DIFF
--- a/services/backend/src/main.py
+++ b/services/backend/src/main.py
@@ -28,7 +28,7 @@ app.add_middleware(
 app.include_router(users.router)
 app.include_router(notes.router)
 
-register_tortoise(app, config=TORTOISE_ORM, generate_schemas=False)
+register_tortoise(app, config=TORTOISE_ORM, generate_schemas=True)
 
 
 @app.get("/")

--- a/services/backend/src/main.py
+++ b/services/backend/src/main.py
@@ -28,7 +28,7 @@ app.add_middleware(
 app.include_router(users.router)
 app.include_router(notes.router)
 
-register_tortoise(app, config=TORTOISE_ORM, generate_schemas=True)
+register_tortoise(app, config=TORTOISE_ORM, generate_schemas=False)
 
 
 @app.get("/")

--- a/services/frontend/src/components/NavBar.vue
+++ b/services/frontend/src/components/NavBar.vue
@@ -49,6 +49,7 @@ export default {
   methods: {
     async logout () {
       await this.$store.dispatch('logOut');
+      await this.$store.commit('isLoggedIn', false);
       this.$router.push('/login');
     }
   },


### PR DESCRIPTION
Without change state isLoggedIn=false we can see and have access to all NavBar options (like Dashboard, Profile). This patch disable access to Dashboard and Profile after click logOut on frontend.