### PR TITLE
Moving the model init to register.py

### DIFF
--- a/services/backend/src/database/register.py
+++ b/services/backend/src/database/register.py
@@ -17,3 +17,5 @@ def register_tortoise(
     @app.on_event("shutdown")
     async def close_orm():
         await Tortoise.close_connections()
+
+Tortoise.init_models(["src.database.models"], "models")

--- a/services/backend/src/main.py
+++ b/services/backend/src/main.py
@@ -4,16 +4,6 @@ from tortoise import Tortoise
 
 from src.database.register import register_tortoise
 from src.database.config import TORTOISE_ORM
-
-
-# enable schemas to read relationship between models
-Tortoise.init_models(["src.database.models"], "models")
-
-"""
-import 'from src.routes import users, notes' must be after 'Tortoise.init_models'
-why?
-https://stackoverflow.com/questions/65531387/tortoise-orm-for-python-no-returns-relations-of-entities-pyndantic-fastapi
-"""
 from src.routes import users, notes
 
 app = FastAPI()


### PR DESCRIPTION
This will initialize the model relationships with register.py and fix the issue below. This will cleanup `main.py`

Issue referenced:
https://stackoverflow.com/questions/65531387/tortoise-orm-for-python-no-returns-relations-of-entities-pyndantic-fastapi
